### PR TITLE
fix: handle stale sync hashes during force sync

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -56,6 +56,7 @@ export async function syncCore(
     // do nothing
   }
   const [head, from] = commitHashResult;
+  let logFrom = from;
   if (from) {
     logger.debug(`Extracted a valid commit: ${from}`);
     logger.debug(`(${head})`);
@@ -68,10 +69,16 @@ export async function syncCore(
   let srcLog: LogResult;
   try {
     // '--first-parent' hides children commits of merge commits
-    srcLog = await srcGit.log(from ? { from, to: 'HEAD', '--first-parent': undefined } : undefined);
+    srcLog = await srcGit.log(logFrom ? { from: logFrom, to: 'HEAD', '--first-parent': undefined } : undefined);
   } catch (error) {
-    logger.error(`Failed to get source commit history: ${(error as Error).stack}`);
-    return false;
+    if (opts.force) {
+      logger.warn(`Failed to get source commit history from ${from}; falling back to full sync`);
+      srcLog = await srcGit.log();
+      logFrom = undefined;
+    } else {
+      logger.error(`Failed to get source commit history: ${(error as Error).stack}`);
+      return false;
+    }
   }
 
   const latestHash = srcLog.latest?.hash;
@@ -107,7 +114,7 @@ export async function syncCore(
   }
   const link = `${prefix}${latestHash}`;
   const title = srcTag ? `sync ${srcTag} (${link})` : `sync ${link}`;
-  const body = from
+  const body = logFrom
     ? srcLog.all.map((l) => `* ${l.message}`).join('\n\n')
     : `Replace all the files with those of ${opts.dest} due to missing sync commit.`;
   try {

--- a/test/gitForceSync.test.ts
+++ b/test/gitForceSync.test.ts
@@ -70,3 +70,33 @@ test('Work one-way-git-sync --force to an empty repo', async () => {
   const destTags = await localDestGit.tags();
   expect(destTags.latest).toBeUndefined();
 });
+
+test('Work one-way-git-sync --force when the destination sync hash is missing from source', async () => {
+  const localDestGit = simpleGit(LOCAL_DEST_DIR);
+  const localSrcGit = simpleGit(LOCAL_SRC_DIR);
+
+  await fs.writeFile(path.join(LOCAL_DEST_DIR, 'dest.txt'), 'Dest Repository');
+  await localDestGit.add('.');
+  await localDestGit.commit(`sync ${'a'.repeat(40)}`);
+  await localDestGit.push(['-u', 'origin', 'main']);
+
+  const ret = await syncCore(await createRepoDir(), { ...DEFAULT_OPTIONS, verbose: true, force: true }, LOCAL_SRC_DIR);
+  expect(ret).toBe(true);
+
+  await localDestGit.pull();
+
+  const destFilePath = path.join(LOCAL_DEST_DIR, 'dest.txt');
+  await expect(fs.lstat(destFilePath)).rejects.toThrow();
+
+  const syncedSrcFilePath = path.join(LOCAL_DEST_DIR, 'src.txt');
+  await expect(fs.lstat(syncedSrcFilePath)).resolves.not.toThrow();
+  const syncedSrcFileContent = await fs.readFile(syncedSrcFilePath, 'utf8');
+  expect(syncedSrcFileContent).toBe('Src Repository');
+
+  const srcLog = await localSrcGit.log();
+  const destLog = await localDestGit.log();
+  expect(destLog.latest?.message).toBe(`sync ${srcLog.latest?.hash}`);
+  expect(destLog.latest?.body).toBe(
+    `Replace all the files with those of ${DEFAULT_OPTIONS.dest} due to missing sync commit.\n`
+  );
+});


### PR DESCRIPTION
## Summary

- Fall back to a full source log when `--force` finds a destination sync hash that no longer exists in the source repository.
- Treat that fallback as a replacement sync so the generated commit body matches force initialization behavior.
- Add a regression test for a stale destination sync hash.

## Why

- `yarn sync-force` in `reusable-workflows` failed because the destination repository pointed at source hash `218b7aa88f43ba2b673a7abab24ec13a338d987d`, which is no longer reachable from the current source checkout.
- Non-force sync should continue failing on an invalid source range, but force sync is expected to overwrite the destination safely.

## Testing

- `yarn test test/gitForceSync.test.ts`
- `yarn check-for-ai`
- `node /Users/exkazuu/ghq/github.com/WillBooster/one-way-git-sync/dist/index.js -v -i node_modules -i renovate.json -d git@github.com:WillBoosterLab/reusable-workflows.git --force --dry` from `/Users/exkazuu/ghq/github.com/WillBooster/reusable-workflows`
