### PR TITLE
chore: apply wbfy

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/yargs": "17.0.35",
     "@typescript/native-preview": "7.0.0-dev.20260415.1",
     "@willbooster/oxfmt-config": "1.2.0",
-    "@willbooster/oxlint-config": "1.4.0",
+    "@willbooster/oxlint-config": "1.4.1",
     "@willbooster/prettier-config": "10.4.0",
     "build-ts": "17.0.26",
     "conventional-changelog-conventionalcommits": "9.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3308,13 +3308,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@willbooster/oxlint-config@npm:1.4.0":
-  version: 1.4.0
-  resolution: "@willbooster/oxlint-config@npm:1.4.0"
+"@willbooster/oxlint-config@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@willbooster/oxlint-config@npm:1.4.1"
   peerDependencies:
     oxlint: ">=1.60.0"
     oxlint-tsgolint: ">=0.18.1"
-  checksum: 10c0/8b298e130818b65efcaf8058d4eba7acdcfd95834790e1fa4a6677061a26905e7c6b195ada225fb3f04814af58d041374be4b11f7c64098c5b22951e1eb0f184
+  checksum: 10c0/8f41637a0bbd3cd0326070351fd317dec893073eed97bbd8f71c5d6b391f8dacc4b354d3d179bfc1dac60c3e3554c54d615b4f6592ecadf6b8185c4bd08046da
   languageName: node
   linkType: hard
 
@@ -6315,7 +6315,7 @@ __metadata:
     "@types/yargs": "npm:17.0.35"
     "@typescript/native-preview": "npm:7.0.0-dev.20260415.1"
     "@willbooster/oxfmt-config": "npm:1.2.0"
-    "@willbooster/oxlint-config": "npm:1.4.0"
+    "@willbooster/oxlint-config": "npm:1.4.1"
     "@willbooster/prettier-config": "npm:10.4.0"
     build-ts: "npm:17.0.26"
     conventional-changelog-conventionalcommits: "npm:9.3.1"


### PR DESCRIPTION
## Summary

- Apply the latest `wbfy` output for this repository.
- Update `@willbooster/oxlint-config` from `1.4.0` to `1.4.1`.
- Refresh `yarn.lock` for the updated tooling dependency.

## Why

- Keeps the repository aligned with the shared WillBooster automation and lint configuration.

## Testing

- `yarn check-for-ai`
- `yarn cleanup`
- pre-push `check.sh` hook
