### PR TITLE
chore: update build-ts to v19 and apply latest wbfy

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -12,15 +12,13 @@ concurrency:
 jobs:
   autofix:
     runs-on: ubuntu-latest
+    env:
+      WB_ENV: development
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: jdx/mise-action@v4.2.0
         with:
-          check-latest: true
-          node-version: lts/*
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+          cache: true
       - run: bun install
       - run: bun run cleanup
       - run: bun run build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Test](https://github.com/WillBooster/one-way-git-sync/actions/workflows/test.yml/badge.svg)](https://github.com/WillBooster/one-way-git-sync/actions/workflows/test.yml)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-[![wbfy](https://img.shields.io/badge/wbfy-4.2.2-1e90ff.svg)](https://github.com/WillBooster/shared/tree/main/packages/wbfy)
+[![wbfy](https://img.shields.io/badge/wbfy-4.3.1-1e90ff.svg)](https://github.com/WillBooster/shared/tree/main/packages/wbfy)
 
 :arrows_counterclockwise: A tool for synchronizing a destination git repository with a source git repository SAFELY.
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
         "@willbooster/wb": "15.1.1",
-        "build-ts": "18.0.0",
+        "build-ts": "19.0.0",
         "conventional-changelog-conventionalcommits": "10.2.1",
         "lefthook": "2.1.10",
         "oxfmt": "0.59.0",
@@ -632,7 +632,7 @@
 
     "@willbooster/oxlint-config": ["@willbooster/oxlint-config@1.4.8", "", { "peerDependencies": { "oxlint": ">=1.60.0", "oxlint-tsgolint": ">=0.18.1" } }, "sha512-i3WWcAc1N6QzA91321dJFGUxXYuuXG4bj12pKlyjCmQRqrulvshFW35PUcaRdw1pVr7I7zHEGK1WUIjbkBd3Vg=="],
 
-    "@willbooster/shared-lib-node": ["@willbooster/shared-lib-node@8.7.0", "", { "dependencies": { "dotenv": "17.4.2", "dotenv-expand": "13.0.0" } }, "sha512-D2hy277mCSW6fV9VIqXFM7A2o4j99JDuHNGnaskzRI1uBrcMoJoJqNLTlFtLKGFoHOhqqsVQmTFcCtHbvYQ9Fg=="],
+    "@willbooster/shared-lib-node": ["@willbooster/shared-lib-node@10.1.0", "", { "dependencies": { "@types/yargs": "17.0.35", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fast-glob": "3.3.3" } }, "sha512-sOxmqZs5xrn5UOo8+wZz4tONZZgSc3G4g0CC769o2eFR5ooxXN5pVkvhLPU6v+JYGrGW3ytV5Uaa7aso0NEAFQ=="],
 
     "@willbooster/wb": ["@willbooster/wb@15.1.1", "", { "dependencies": { "chalk": "5.6.2", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fast-glob": "3.3.3", "fastest-levenshtein": "1.0.16", "globby": "16.2.0", "jsonc-parser": "3.3.1", "kill-port": "2.0.1", "minimal-promise-pool": "6.0.2", "semver": "7.8.5", "yargs": "18.0.0" }, "bin": { "wb": "bin/index.js" } }, "sha512-LcgW+PH3Sa7G2nhrs9FgfiBTEnFRYYU2oidHB3y8Z1NZDuOxEsKvulpKQYE4f74FcHdtmLPAUM1mFJk2Z9xK4g=="],
 
@@ -670,7 +670,7 @@
 
     "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
 
-    "build-ts": ["build-ts@18.0.0", "", { "dependencies": { "@babel/core": "8.0.1", "@babel/plugin-proposal-decorators": "8.0.2", "@babel/plugin-transform-explicit-resource-management": "8.0.1", "@babel/preset-env": "8.0.2", "@babel/preset-react": "8.0.1", "@babel/preset-typescript": "8.0.1", "@willbooster/shared-lib-node": "8.7.0", "magic-string": "0.30.21", "oxc-parser": "0.139.0", "rolldown": "1.1.5", "signal-exit": "4.1.0", "tsx": "4.23.1", "typescript": "7.0.2", "yargs": "18.0.0" }, "bin": { "build-ts": "bin/index.js" } }, "sha512-ffZaqXkPN7J94jifokyJBdKColmpyJG8IpwsnJhWtK05TYlgcjyHMS00AuMU/k+9/FEW0mkMYNLLuFKszoRw0w=="],
+    "build-ts": ["build-ts@19.0.0", "", { "dependencies": { "@babel/core": "8.0.1", "@babel/plugin-proposal-decorators": "8.0.2", "@babel/plugin-transform-explicit-resource-management": "8.0.1", "@babel/preset-env": "8.0.2", "@babel/preset-react": "8.0.1", "@babel/preset-typescript": "8.0.1", "@willbooster/shared-lib-node": "10.1.0", "magic-string": "0.30.21", "oxc-parser": "0.139.0", "rolldown": "1.1.5", "signal-exit": "4.1.0", "tsx": "4.23.1", "typescript": "7.0.2", "yargs": "18.0.0" }, "bin": { "build-ts": "bin/index.js" } }, "sha512-+wbFotjzP+vraFj1Xqg4xKpADn0g3lp+cs8/aZ11iuaEP/ruTWExvQ5wLDmateiiyZ6FZsq6GJBS/1VPa+ucXg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
     "@willbooster/wb": "15.1.1",
-    "build-ts": "18.0.0",
+    "build-ts": "19.0.0",
     "conventional-changelog-conventionalcommits": "10.2.1",
     "lefthook": "2.1.10",
     "oxfmt": "0.59.0",


### PR DESCRIPTION
## Summary
- Updates `build-ts` from 18.0.0 to 19.0.0
- Applies latest `wbfy` (wbfy badge 4.2.2 → 4.3.1), replacing `actions/setup-node` + `oven-sh/setup-bun` with `jdx/mise-action@v4.2.0` in the autofix workflow

Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>
