### PR TITLE
fix: stop the clone fallback from pushing to a branch named "undefined"

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -55,13 +55,32 @@ export async function syncCore(
     // reason ends up syncing from the wrong history with no other trace of why.
     // Only --branch is named because --depth (set for every non-force run) implies --single-branch,
     // so deleting the latter changes nothing unless --force also dropped --depth.
-    logger.warn(`Retrying the clone without --branch after: ${redactUrlCredentials((error as Error).message)}`);
+    // `error` is whatever simple-git rejected with, which is always a GitError (an Error subclass);
+    // the cast documents that rather than guarding an unreachable shape.
+    const reason = redactUrlCredentials((error as Error).message);
+    logger.warn(`Retrying the clone ${opts.branch ? 'without --branch ' : ''}after: ${reason}`);
     await simpleGit(srcRepoPath).clone(opts.dest, destRepoPath, cloneOpts);
     if (opts.branch) {
-      // -B, not -b: the retry clone checks out the destination's default branch, so a requested
-      // branch that already exists there (--branch main is the common case) would make -b fail with
-      // `fatal: a branch named 'main' already exists`.
-      await simpleGit(destRepoPath).checkout(['-B', opts.branch]);
+      const retryGit = simpleGit(destRepoPath);
+      // The retry dropped --branch, so it landed on the destination's DEFAULT branch. When that is
+      // the requested branch (--branch main, the common case) there is nothing left to do.
+      const headRef = await retryGit.revparse(['--abbrev-ref', 'HEAD']);
+      const currentBranch = headRef.trim();
+      if (currentBranch !== opts.branch) {
+        // The requested branch existing on the remote means the first clone did not fail because it
+        // was missing — so this was an unrelated failure, and creating the branch here would point
+        // it at the default branch's tip. That silently syncs from the wrong history: a diverged
+        // branch is rejected on push with a misleading error, and one that is an ancestor of the
+        // default branch fast-forwards and absorbs its commits while reporting success.
+        const remoteHeads = await retryGit.listRemote(['--heads', 'origin', opts.branch]);
+        if (remoteHeads.trim()) {
+          logger.error(`Cloning failed and branch ${opts.branch} already exists on the destination: ${reason}`);
+          return false;
+        }
+        // Absent from the remote, so this is the case the fallback exists for. -b would do here too;
+        // -B just avoids depending on the fresh clone never having the branch locally.
+        await retryGit.checkout(['-B', opts.branch]);
+      }
     }
   }
   logger.debug(`Cloned destination repo on ${destRepoPath}`);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -64,7 +64,11 @@ export async function syncCore(
       const retryGit = simpleGit(destRepoPath);
       // The retry dropped --branch, so it landed on the destination's DEFAULT branch. When that is
       // the requested branch (--branch main, the common case) there is nothing left to do.
-      const headRef = await retryGit.revparse(['--abbrev-ref', 'HEAD']);
+      // `branch --show-current`, not `rev-parse --abbrev-ref HEAD`: the latter exits 128 on an
+      // unborn HEAD, and an empty destination is one of the cases this fallback exists for
+      // (--force --branch <new> bootstraps a fresh mirror). Inside a catch, that rejection would
+      // escape syncCore entirely instead of returning false.
+      const headRef = await retryGit.raw(['branch', '--show-current']);
       const currentBranch = headRef.trim();
       if (currentBranch !== opts.branch) {
         // The requested branch existing on the remote means the first clone did not fail because it
@@ -72,7 +76,10 @@ export async function syncCore(
         // it at the default branch's tip. That silently syncs from the wrong history: a diverged
         // branch is rejected on push with a misleading error, and one that is an ancestor of the
         // default branch fast-forwards and absorbs its commits while reporting success.
-        const remoteHeads = await retryGit.listRemote(['--heads', 'origin', opts.branch]);
+        // Fully qualified: `ls-remote --heads origin released` matches by ref TAIL with complete
+        // path components, so it also returns refs/heads/feature/released and would wrongly
+        // report the branch as existing.
+        const remoteHeads = await retryGit.listRemote(['--heads', 'origin', `refs/heads/${opts.branch}`]);
         if (remoteHeads.trim()) {
           logger.error(`Cloning failed and branch ${opts.branch} already exists on the destination: ${reason}`);
           return false;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { copy } from 'fs-extra';
 import micromatch from 'micromatch';
-import type { LogResult, Options, SimpleGit, TaskOptions } from 'simple-git';
+import type { LogResult, Options, SimpleGit } from 'simple-git';
 import { simpleGit } from 'simple-git';
 import type { InferredOptionTypes } from 'yargs';
 
@@ -39,11 +39,25 @@ export async function syncCore(
   }
   try {
     await simpleGit(srcRepoPath).clone(opts.dest, destRepoPath, cloneOpts);
-  } catch {
+  } catch (error) {
+    // This fallback exists for one case: --branch names a branch the destination does not have yet,
+    // so the narrow clone cannot find it and the branch has to be created locally instead. The
+    // clone can equally fail for unrelated reasons (a flaky network, a bad URL, missing auth),
+    // which is why creating the branch is conditional on one actually having been REQUESTED.
+    // Creating it unconditionally used to read `checkout(['-b', undefined])` — simple-git renders
+    // that as `-b undefined`, so a transient network error silently turned into a commit pushed to
+    // a branch literally named "undefined" while the real branch stayed behind. simple-git's
+    // permissive `checkout` overloads accept the undefined, so the compiler does not catch it.
     delete cloneOpts['--branch'];
     delete cloneOpts['--single-branch'];
     await simpleGit(srcRepoPath).clone(opts.dest, destRepoPath, cloneOpts);
-    await simpleGit(destRepoPath).checkout(['-b', opts.branch] as TaskOptions);
+    if (opts.branch) {
+      await simpleGit(destRepoPath).checkout(['-b', opts.branch]);
+    } else {
+      // Nothing was requested, so this was the unrelated-failure case. The retry may well have
+      // succeeded, but say so: a silently swallowed clone error is how the bug above went unnoticed.
+      logger.warn(`Retried cloning ${opts.dest} without --single-branch/--depth after: ${(error as Error).message}`);
+    }
   }
   logger.debug(`Cloned destination repo on ${destRepoPath}`);
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -42,21 +42,26 @@ export async function syncCore(
   } catch (error) {
     // This fallback exists for one case: --branch names a branch the destination does not have yet,
     // so the narrow clone cannot find it and the branch has to be created locally instead. The
-    // clone can equally fail for unrelated reasons (a flaky network, a bad URL, missing auth),
-    // which is why creating the branch is conditional on one actually having been REQUESTED.
-    // Creating it unconditionally used to read `checkout(['-b', undefined])` — simple-git renders
-    // that as `-b undefined`, so a transient network error silently turned into a commit pushed to
-    // a branch literally named "undefined" while the real branch stayed behind. simple-git's
-    // permissive `checkout` overloads accept the undefined, so the compiler does not catch it.
+    // clone can equally fail for unrelated reasons (a flaky network, a bad URL, missing auth), in
+    // which case there is no branch to create — hence the conditional below. Creating it
+    // unconditionally used to read `checkout(['-b', undefined])`, which simple-git renders as
+    // `-b undefined`, so a transient network error silently turned into a commit pushed to a branch
+    // literally named "undefined" while the real branch stayed behind. simple-git's permissive
+    // `checkout` overloads accept the undefined, so the compiler does not catch it.
     delete cloneOpts['--branch'];
     delete cloneOpts['--single-branch'];
+    // Reported for BOTH cases, before the retry: whichever one this was, discarding the original
+    // error is what let the bug above go unnoticed, and a --branch run that fails for an unrelated
+    // reason ends up syncing from the wrong history with no other trace of why.
+    // Only --branch is named because --depth (set for every non-force run) implies --single-branch,
+    // so deleting the latter changes nothing unless --force also dropped --depth.
+    logger.warn(`Retrying the clone without --branch after: ${redactUrlCredentials((error as Error).message)}`);
     await simpleGit(srcRepoPath).clone(opts.dest, destRepoPath, cloneOpts);
     if (opts.branch) {
-      await simpleGit(destRepoPath).checkout(['-b', opts.branch]);
-    } else {
-      // Nothing was requested, so this was the unrelated-failure case. The retry may well have
-      // succeeded, but say so: a silently swallowed clone error is how the bug above went unnoticed.
-      logger.warn(`Retried cloning ${opts.dest} without --single-branch/--depth after: ${(error as Error).message}`);
+      // -B, not -b: the retry clone checks out the destination's default branch, so a requested
+      // branch that already exists there (--branch main is the common case) would make -b fail with
+      // `fatal: a branch named 'main' already exists`.
+      await simpleGit(destRepoPath).checkout(['-B', opts.branch]);
     }
   }
   logger.debug(`Cloned destination repo on ${destRepoPath}`);
@@ -189,4 +194,13 @@ function extractCommitHash(logResult: LogResult): [string, string] | [] {
     logger.debug(`No sync commit: ${firstLog.message}`);
   }
   return [];
+}
+
+/**
+ * Replaces the `user:password@` part of every URL in the text. The README recommends passing the
+ * destination as `https://oauth2:<PAT>@github.com/...`, and git echoes the URL back in its error
+ * messages, so logging either one verbatim would print the token into console and CI logs.
+ */
+export function redactUrlCredentials(text: string): string {
+  return text.replaceAll(/([A-Za-z][\w+.-]*:\/\/)[^/\s]*@/g, '$1***@');
 }

--- a/test/gitSyncCloneFallback.test.ts
+++ b/test/gitSyncCloneFallback.test.ts
@@ -121,6 +121,44 @@ test('a clone failure with --branch naming an existing non-default branch fails 
   expect(releasedLog.latest?.message).toBe(syncCommitMessage);
 });
 
+test('a branch whose name is the tail of another branch is still treated as absent', async () => {
+  // `ls-remote --heads origin released` also matches refs/heads/feature/released, so a bare
+  // pattern would report the requested branch as existing and refuse to create it.
+  const localDestGit = simpleGit(LOCAL_DEST_DIR);
+  await localDestGit.checkoutLocalBranch('feature/released');
+  await localDestGit.push(['-u', 'origin', 'feature/released']);
+  await localDestGit.checkout('main');
+
+  failNextClone = true;
+
+  const { syncCore } = await import('../src/sync.js');
+  const ret = await syncCore(await createRepoDir(), { ...DEFAULT_OPTIONS, branch: 'released' }, LOCAL_SRC_DIR);
+  expect(failNextClone).toBe(false);
+  expect(ret).toBe(true);
+
+  const branches = await simpleGit(REMOTE_DEST_DIR).branch();
+  expect(branches.all).toContain('released');
+});
+
+test('a destination with no commits at all does not crash the fallback', async () => {
+  // --force --branch <new> bootstrapping an empty mirror is a supported entry point, and there the
+  // retry clone lands on an unborn HEAD. No mock: the first clone really fails because the branch
+  // does not exist on the destination.
+  const emptyRemoteDir = await fs.mkdtemp(path.join(TEMP_DIR, 'remote-empty-'));
+  await simpleGit(emptyRemoteDir).init(true, ['--initial-branch=main']);
+
+  const { syncCore } = await import('../src/sync.js');
+  const ret = await syncCore(
+    await createRepoDir(),
+    { ...DEFAULT_OPTIONS, dest: emptyRemoteDir, branch: 'released', force: true },
+    LOCAL_SRC_DIR
+  );
+  expect(ret).toBe(true);
+
+  const branches = await simpleGit(emptyRemoteDir).branch();
+  expect(branches.all).toContain('released');
+});
+
 test('a clone failure with --branch pointing at an existing branch still succeeds', async () => {
   failNextClone = true;
 

--- a/test/gitSyncCloneFallback.test.ts
+++ b/test/gitSyncCloneFallback.test.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type * as SimpleGitModule from 'simple-git';
+import { simpleGit } from 'simple-git';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { DEFAULT_OPTIONS, LOCAL_DEST_DIR, LOCAL_SRC_DIR, REMOTE_DEST_DIR, TEMP_DIR } from './constants.js';
+import { createRepoDir, setUpGit } from './shared.js';
+
+// The clone fallback is only reachable when the first clone throws, which a local-path clone never
+// does on its own, so the first call is failed deliberately. Without that injection the branch
+// handling in the fallback cannot be exercised at all.
+vi.mock('simple-git', async () => {
+  const actual = await vi.importActual<typeof SimpleGitModule>('simple-git');
+  return {
+    ...actual,
+    simpleGit: (...args: Parameters<typeof actual.simpleGit>) => {
+      const git = actual.simpleGit(...args);
+      const clone = git.clone.bind(git);
+      git.clone = ((...cloneArgs: Parameters<typeof clone>) => {
+        if (failNextClone) {
+          failNextClone = false;
+          return Promise.reject(new Error('simulated transient clone failure'));
+        }
+        return clone(...cloneArgs);
+      }) as typeof git.clone;
+      return git;
+    },
+  };
+});
+
+let failNextClone = false;
+
+beforeEach(async () => {
+  failNextClone = false;
+  await fs.rm(TEMP_DIR, { force: true, recursive: true });
+  await fs.mkdir(LOCAL_SRC_DIR, { recursive: true });
+  await fs.mkdir(LOCAL_DEST_DIR, { recursive: true });
+  await fs.mkdir(REMOTE_DEST_DIR, { recursive: true });
+
+  await setUpGit();
+
+  await simpleGit(REMOTE_DEST_DIR).init(true, ['--initial-branch=main']);
+
+  // The destination's sync commit has to name a commit that really exists in the source, otherwise
+  // syncCore fails while reading the source history and never reaches the branch handling.
+  const localSrcGit = simpleGit(LOCAL_SRC_DIR);
+  await localSrcGit.init(false, ['--initial-branch=main']);
+  await fs.writeFile(path.join(LOCAL_SRC_DIR, 'src.txt'), 'Src Repository');
+  await localSrcGit.add('.');
+  await localSrcGit.commit('Initial commit');
+  const srcLog = await localSrcGit.log();
+  const syncedHash = srcLog.latest?.hash;
+
+  const localDestGit = simpleGit(LOCAL_DEST_DIR);
+  await localDestGit.init(false, ['--initial-branch=main']);
+  await localDestGit.remote(['add', 'origin', REMOTE_DEST_DIR]);
+  await fs.writeFile(path.join(LOCAL_DEST_DIR, 'dest.txt'), 'Dest Repository');
+  await localDestGit.add('.');
+  await localDestGit.commit(`sync https://github.com/WillBooster/one-way-git-sync/commits/${syncedHash}`);
+  await localDestGit.push(['-u', 'origin', 'main']);
+
+  // Something for this run to actually synchronize.
+  await fs.writeFile(path.join(LOCAL_SRC_DIR, 'added.txt'), 'Added');
+  await localSrcGit.add('.');
+  await localSrcGit.commit('Add a file to synchronize');
+});
+
+test('a clone failure without --branch never pushes to a branch named "undefined"', async () => {
+  failNextClone = true;
+
+  const { syncCore } = await import('../src/sync.js');
+  const ret = await syncCore(await createRepoDir(), { ...DEFAULT_OPTIONS, branch: undefined }, LOCAL_SRC_DIR);
+  expect(ret).toBe(true);
+
+  const branches = await simpleGit(REMOTE_DEST_DIR).branch();
+  expect(branches.all).not.toContain('undefined');
+  expect(branches.all).toContain('main');
+});
+
+test('a clone failure with --branch creates and pushes that branch', async () => {
+  failNextClone = true;
+
+  const { syncCore } = await import('../src/sync.js');
+  const ret = await syncCore(await createRepoDir(), { ...DEFAULT_OPTIONS, branch: 'released' }, LOCAL_SRC_DIR);
+  expect(ret).toBe(true);
+
+  const branches = await simpleGit(REMOTE_DEST_DIR).branch();
+  expect(branches.all).toContain('released');
+  expect(branches.all).not.toContain('undefined');
+});

--- a/test/gitSyncCloneFallback.test.ts
+++ b/test/gitSyncCloneFallback.test.ts
@@ -31,6 +31,7 @@ vi.mock('simple-git', async () => {
 });
 
 let failNextClone = false;
+let syncCommitMessage = '';
 
 beforeEach(async () => {
   // vitest.config.ts sets `isolate: false`, and sibling test files import src/sync.ts
@@ -64,7 +65,8 @@ beforeEach(async () => {
   await localDestGit.remote(['add', 'origin', REMOTE_DEST_DIR]);
   await fs.writeFile(path.join(LOCAL_DEST_DIR, 'dest.txt'), 'Dest Repository');
   await localDestGit.add('.');
-  await localDestGit.commit(`sync https://github.com/WillBooster/one-way-git-sync/commits/${syncedHash}`);
+  syncCommitMessage = `sync https://github.com/WillBooster/one-way-git-sync/commits/${syncedHash}`;
+  await localDestGit.commit(syncCommitMessage);
   await localDestGit.push(['-u', 'origin', 'main']);
 
   // Something for this run to actually synchronize.
@@ -97,6 +99,26 @@ test('a clone failure with --branch creates and pushes that branch', async () =>
   const branches = await simpleGit(REMOTE_DEST_DIR).branch();
   expect(branches.all).toContain('released');
   expect(branches.all).not.toContain('undefined');
+});
+
+test('a clone failure with --branch naming an existing non-default branch fails instead of rewriting it', async () => {
+  // Give the destination a second branch that is NOT its default, which is the shape that made the
+  // old `-B` repoint it at the default branch's tip and sync from the wrong history.
+  const localDestGit = simpleGit(LOCAL_DEST_DIR);
+  await localDestGit.checkoutLocalBranch('released');
+  await localDestGit.push(['-u', 'origin', 'released']);
+  await localDestGit.checkout('main');
+
+  failNextClone = true;
+
+  const { syncCore } = await import('../src/sync.js');
+  const ret = await syncCore(await createRepoDir(), { ...DEFAULT_OPTIONS, branch: 'released' }, LOCAL_SRC_DIR);
+  expect(failNextClone).toBe(false);
+  // A transient failure must surface, not be turned into a sync onto the wrong history.
+  expect(ret).toBe(false);
+
+  const releasedLog = await simpleGit(REMOTE_DEST_DIR).log(['released']);
+  expect(releasedLog.latest?.message).toBe(syncCommitMessage);
 });
 
 test('a clone failure with --branch pointing at an existing branch still succeeds', async () => {

--- a/test/gitSyncCloneFallback.test.ts
+++ b/test/gitSyncCloneFallback.test.ts
@@ -33,6 +33,12 @@ vi.mock('simple-git', async () => {
 let failNextClone = false;
 
 beforeEach(async () => {
+  // vitest.config.ts sets `isolate: false`, and sibling test files import src/sync.ts
+  // statically. Without this reset the dynamic import below can resolve to an already-evaluated
+  // copy bound to the REAL simple-git, so the injected failure never fires and these tests pass
+  // while asserting nothing. Each test also asserts the injection fired, so it cannot degrade
+  // back into a silent no-op.
+  vi.resetModules();
   failNextClone = false;
   await fs.rm(TEMP_DIR, { force: true, recursive: true });
   await fs.mkdir(LOCAL_SRC_DIR, { recursive: true });
@@ -72,6 +78,7 @@ test('a clone failure without --branch never pushes to a branch named "undefined
 
   const { syncCore } = await import('../src/sync.js');
   const ret = await syncCore(await createRepoDir(), { ...DEFAULT_OPTIONS, branch: undefined }, LOCAL_SRC_DIR);
+  expect(failNextClone).toBe(false);
   expect(ret).toBe(true);
 
   const branches = await simpleGit(REMOTE_DEST_DIR).branch();
@@ -84,9 +91,24 @@ test('a clone failure with --branch creates and pushes that branch', async () =>
 
   const { syncCore } = await import('../src/sync.js');
   const ret = await syncCore(await createRepoDir(), { ...DEFAULT_OPTIONS, branch: 'released' }, LOCAL_SRC_DIR);
+  expect(failNextClone).toBe(false);
   expect(ret).toBe(true);
 
   const branches = await simpleGit(REMOTE_DEST_DIR).branch();
   expect(branches.all).toContain('released');
   expect(branches.all).not.toContain('undefined');
+});
+
+test('a clone failure with --branch pointing at an existing branch still succeeds', async () => {
+  failNextClone = true;
+
+  const { syncCore } = await import('../src/sync.js');
+  // The retry clone checks out the destination's default branch, so `checkout -b main` would fail
+  // with "a branch named 'main' already exists". This is the shape reusable-workflows uses.
+  const ret = await syncCore(await createRepoDir(), { ...DEFAULT_OPTIONS, branch: 'main' }, LOCAL_SRC_DIR);
+  expect(failNextClone).toBe(false);
+  expect(ret).toBe(true);
+
+  const branches = await simpleGit(REMOTE_DEST_DIR).branch();
+  expect(branches.all).toEqual(['main']);
 });

--- a/test/redactUrlCredentials.test.ts
+++ b/test/redactUrlCredentials.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest';
+
+import { redactUrlCredentials } from '../src/sync.js';
+
+// The README recommends passing the destination as `https://oauth2:<PAT>@github.com/...`, and git
+// echoes that URL back in its error text, so anything logged from a clone failure can carry a token.
+// The WHOLE userinfo goes, username included: GitHub also accepts a bare token as the username
+// (`https://ghp_...@github.com/...`), so keeping that half would leak exactly the same secret.
+test.each<{ label: string; input: string; expected: string }>([
+  {
+    label: 'a PAT in the destination URL',
+    input: "fatal: could not read from 'https://oauth2:ghp_secretTokenValue@github.com/owner/repo.git'",
+    expected: "fatal: could not read from 'https://***@github.com/owner/repo.git'",
+  },
+  {
+    label: 'user:password credentials',
+    input: 'remote: https://alice:s3cr3t@example.com/repo.git rejected',
+    expected: 'remote: https://***@example.com/repo.git rejected',
+  },
+  {
+    label: 'a bare token as the username',
+    input: 'fatal: unable to access https://ghp_secretTokenValue@github.com/owner/repo.git/',
+    expected: 'fatal: unable to access https://***@github.com/owner/repo.git/',
+  },
+  {
+    label: 'two URLs in one message',
+    input: 'https://a:1@x.com/r.git and https://b:2@y.com/r.git',
+    expected: 'https://***@x.com/r.git and https://***@y.com/r.git',
+  },
+])('redacts $label', ({ input, expected }) => {
+  expect(redactUrlCredentials(input)).toBe(expected);
+});
+
+test.each<{ label: string; input: string }>([
+  { label: 'a URL without credentials', input: 'fatal: repository https://github.com/owner/repo.git not found' },
+  // scp-like SSH remotes carry no secret, and the `@` sits after no `://`, so nothing should change.
+  { label: 'an scp-like SSH remote', input: 'fatal: could not read from git@github.com:owner/repo.git' },
+  { label: 'an email address in prose', input: 'committer bot@willbooster.com is not allowed' },
+  { label: 'a message with no URL at all', input: 'simulated transient clone failure' },
+])('leaves $label untouched', ({ input }) => {
+  expect(redactUrlCredentials(input)).toBe(input);
+});


### PR DESCRIPTION
## Customer Summary

- A transient clone failure no longer sends a sync to a branch literally named `undefined`. Previously the sync reported success while the real branch stayed behind, so a mirror could silently go stale.
- A transient failure combined with `--branch` no longer rewrites an existing destination branch, and no longer crashes when the requested branch already exists or when the destination is empty.
- Retries are now reported in the log, with any credentials in the URL redacted.

## Technical Summary

`syncCore`'s clone fallback exists for one case: `--branch` names a branch the destination does not have yet, so the narrow clone cannot find it and the branch has to be created locally. It ran unconditionally:

```ts
await simpleGit(destRepoPath).checkout(['-b', opts.branch] as TaskOptions);
```

`opts.branch` is optional and the `as TaskOptions` cast hid that, so with no `--branch` and a clone that failed for an unrelated reason this became `git checkout -b undefined`.

The fallback is now explicit about which case it is in:

- Branch creation happens only when a branch was requested, and the cast is gone.
- The requested branch is compared against the retry clone's checked-out branch (the destination's **default** branch, since the retry drops `--branch`). Equal means nothing to do — that is `--branch main`, what `WillBooster/reusable-workflows` passes.
- Otherwise the branch's existence on the remote decides: **absent** is the case the fallback is for, so it is created with `-B`; **present** means the first clone did not fail for a missing branch, so the original error is logged and `syncCore` returns `false` instead of repointing that branch at the default branch's tip.
- The original clone error is always logged, for both cases, with credentials redacted.

## Why

Observed in production while syncing `WillBooster/reusable-workflows` to its `WillBoosterLab` mirror over a flaky connection. The run logged `Created a commit: {"branch":"undefined",…}` then `Pushed the commit` and exited 0 — but the mirror gained a `refs/heads/undefined` while `refs/heads/main` never moved, so it stayed several commits behind and every consumer of the missing files kept failing.

The failure mode is bad out of proportion to the bug: the sync exits 0, the destination's default branch is untouched, and the only signal is a `branch` field in a debug line. Note the compiler does **not** protect the original shape — simple-git's `checkout` has a permissive `checkout(options?: TaskOptions, …)` overload, so removing the narrowing still type-checks (verified). The guards are load-bearing, hence the tests below.

## Testing

`test/gitSyncCloneFallback.test.ts` (new, 6 cases). A local-path clone never fails on its own, so the fallback is unreachable without fault injection; the tests mock `simple-git` to fail the first `clone` once, then delegate to the real implementation. Each case additionally asserts the injection actually fired, and `beforeEach` calls `vi.resetModules()` — without it, `isolate: false` plus the sibling files' static imports of `src/sync.ts` let the dynamic import resolve to an unmocked copy, and the suite passed vacuously in 1 of 3 runs.

Every guard was verified against the mutation it exists to catch, not just asserted:

| revert | failing case |
|---|---|
| unconditional `checkout(['-b', opts.branch])` | `…never pushes to a branch named "undefined"` → `expected [ 'main', 'undefined' ] to not include 'undefined'` |
| `-B` back to `-b` | `…with --branch pointing at an existing branch still succeeds` → `fatal: a branch named 'main' already exists` |
| drop the remote-existence check | `…naming an existing non-default branch fails instead of rewriting it` |
| `branch --show-current` back to `revparse(['--abbrev-ref','HEAD'])` | `…with no commits at all does not crash the fallback` → `fatal: ambiguous argument 'HEAD'` |
| bare `ls-remote` pattern | `…whose name is the tail of another branch is still treated as absent` |
| drop `vi.resetModules()` | the injection assertions, in 1 of 3 full-suite runs |

`test/redactUrlCredentials.test.ts` (new, 8 cases): a PAT in the URL, `user:password`, a bare token as the username, two URLs in one message, and four inputs that must stay untouched (no-credential URL, scp-like `git@host:path`, an email address, no URL at all). The whole userinfo is redacted, username included, because GitHub accepts a bare PAT as the username.

`bun verify` passes; `vitest run test` is 35 passed / 2 skipped across 6 files, stable over 3 consecutive full-suite runs.

Git behaviours were each confirmed against git 2.50.1 rather than assumed: `--depth` implies `--single-branch` (so the retry differs only by dropping `--branch`), `rev-parse --abbrev-ref HEAD` exits 128 on an unborn HEAD while `branch --show-current` exits 0, `ls-remote --heads origin released` also matches `refs/heads/feature/released`, and a failed clone leaves a pre-existing destination directory empty so the retry can reuse it.

## Notes

- Consumers can also pass `-b <branch>` explicitly, which makes the branch unambiguous regardless of this fix; `WillBooster/reusable-workflows#482` does that for the Lab mirror.
- Out of scope, found during review: `syncCore` still interpolates `opts.dest` into the **commit body** on the force/no-sync-commit path, so a credential-bearing `--dest` would be committed into the destination. Pre-existing and untouched here (`git diff main...HEAD -- src/sync.ts` shows no change to that line).
- Also out of scope: awaits inside the `catch` can reject and escape `syncCore` rather than returning `false`. That shape is pre-existing — the retry clone itself already sits unguarded in the same `catch` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
